### PR TITLE
fix(security): remove shell=True from subprocess.Popen calls

### DIFF
--- a/core/installer.py
+++ b/core/installer.py
@@ -70,7 +70,7 @@ class InstallerProcess(threading.Thread):
                         if self.progress_callback:
                             self.progress_callback(None)  # Switch to indeterminate mode
                         
-                        process = subprocess.Popen([local_file], shell=True)
+                        process = subprocess.Popen([local_file])
                         process.wait()
                         
                         if process.returncode == 0:
@@ -109,7 +109,7 @@ class InstallerProcess(threading.Thread):
                 if self.progress_callback:
                     self.progress_callback(None)  # Switch to indeterminate mode
                 
-                process = subprocess.Popen([local_file], shell=True)
+                process = subprocess.Popen([local_file])
                 process.wait()
                 
                 if process.returncode == 0:


### PR DESCRIPTION
## Fix: Remove dangerous `shell=True` usage in subprocess

**What does this PR do?**
This PR removes the `shell=True` argument from `subprocess.Popen` calls in `core/installer.py`.

**Why is this change necessary? (Security)**
Using `shell=True` invokes the system shell (cmd.exe) to execute the command, which introduces a potential security vulnerability (Command Injection / CWE-78), especially if file paths contain spaces or special characters.

By removing `shell=True`, the application now spawns the executable directly as a child process. This is:
1. **Safer:** Eliminates shell injection risks.
2. **Standard:** Follows Python `subprocess` security best practices.

**Key Changes:**
* `core/installer.py`: Removed `shell=True` from `subprocess.Popen` calls when launching the downloaded installer.

**How to test:**
1. Run the installer (`python app.py`).
2. Perform a standard installation.
3. Verify that the downloaded application launches correctly at the end of the process (the behavior should remain identical for the user).