### PR TITLE
refactor(ui): remove redundant appearance mode override

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -35,8 +35,7 @@ if windows_dark_mode:
 else:
     ctk.set_appearance_mode("light")
 
-# Set appearance mode and default color theme
-ctk.set_appearance_mode("light")
+# Set default color theme
 ctk.set_default_color_theme("blue")
 
 class AscendaraInstaller(ctk.CTk):


### PR DESCRIPTION
## Refactor: Remove redundant appearance mode call

### What does this PR do?

Removes a redundant `ctk.set_appearance_mode("light")` call that was placed after the dark mode detection logic.

### Why?

The code was confusing - it detected Windows dark mode, then immediately overwrote the setting. While this didn't cause a visible bug (because custom colors handle the theming), the code was misleading and could cause issues if future changes rely on `ctk.set_appearance_mode()`.

### Changes

- **[ui/main_window.py]**: Removed redundant line, updated comment for clarity

### Impact

- No visual changes
- Cleaner, more maintainable code