### PR TITLE
fix(network): add timeout to prevent app freeze on slow network

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -283,7 +283,7 @@ class AscendaraInstaller(ctk.CTk):
         # Try to load logo from URL
         try:
             logo_url = "https://raw.githubusercontent.com/Ascendara/ascendara/refs/heads/main/src/public/icon.png"
-            response = requests.get(logo_url)
+            response = requests.get(logo_url, timeout=5)
             if response.status_code == 200:
                 logo_image = Image.open(BytesIO(response.content))
                 logo_image = logo_image.resize((100, 100), Image.Resampling.LANCZOS)
@@ -337,7 +337,7 @@ class AscendaraInstaller(ctk.CTk):
         
         # Subtitle
         try:
-            response = requests.get("https://api.ascendara.app/")
+            response = requests.get("https://api.ascendara.app/", timeout=5)
             if response.status_code == 200:
                 data = response.json()
                 app_ver = data["appVer"]


### PR DESCRIPTION
## Fix: Add network timeouts to prevent app freeze

**What does this PR do?**
This PR adds a 5-second timeout to the network requests used for fetching the application logo and the version information in `ui/main_window.py`.

**Why is this change necessary?**
By default, the Python `requests` library has no timeout. If the user has a slow internet connection, or if the remote server hangs/drops packets, the installer could freeze indefinitely (blocking the UI) while waiting for a response.

Adding a specific timeout ensures the application fails gracefully (and continues loading) rather than hanging completely during startup.

**Key Changes:**
* Added `timeout=5` parameter to the `requests.get()` call for the remote logo URL.
* Added `timeout=5` parameter to the `requests.get()` call for the Ascendara API version check.

**How to test:**
1. Run the installer (`python app.py`).
2. Verify that the logo and version number still load correctly on a working internet connection (ensure no regression).